### PR TITLE
add option to sendEvent to use named trackers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 bower_components
 node_modules
 .idea/
+*.swp
+.tern-project

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: node_js
+node_js:
+- '5.1'
+- '5.9'
+sudo: false
+before_script:
+- bower install
+- npm install
+script:
+- npm test
+cache:
+  directories:
+  - node_modules
+  - bower_components

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "test": "./node_modules/karma/bin/karma start resources/karma.conf.js"
   },
   "devDependencies": {
+    "bower": "^1.7.9",
     "browserify": "^11.0.0",
     "chai": "^3.2.0",
     "karma": "^0.13.2",

--- a/src/analytics-manager.js
+++ b/src/analytics-manager.js
@@ -151,17 +151,24 @@ var AnalyticsManager = {
     }
   },
 
-  sendEvent: function(trackedEvent) {
+  sendEvent: function(trackedEvent, options) {
     if ((typeof(trackedEvent.eventCategory) === 'undefined') ||
       (typeof(trackedEvent.eventAction) === 'undefined') ||
       (typeof(trackedEvent.eventLabel) === 'undefined')) {
       return;
     }
 
+    var sender;
+    if (options && options.trackerName) {
+      sender = options.trackerName + '.send';
+    } else {
+      sender = 'send';
+    }
+
     if (AnalyticsManager.debugMode()) {
       console.log(trackedEvent);
     } else {
-      ga('send', 'event', trackedEvent);
+      ga(sender, 'event', trackedEvent);
     }
   }
 };

--- a/src/analytics-manager.spec.js
+++ b/src/analytics-manager.spec.js
@@ -317,6 +317,17 @@ describe("AnalyticsManager", function() {
         expect(window.ga.calledWith('send', 'event', trackedEvent)).to.be.true;
       });
     });
+
+    context("with named tracker", function() {
+      beforeEach(function() {
+        window.analyticsTest = false;
+        subject.sendEvent(trackedEvent, { trackerName: 'trackerName' });
+      });
+
+      it("sends the event to GA with the prefix", function() {
+        expect(window.ga.calledWith('trackerName.send', 'event', trackedEvent)).to.be.true;
+      });
+    });
   });
 
   describe("#pathInfo", function() {


### PR DESCRIPTION
@spra85 need to add the trackerName here: https://github.com/theonion/videohub-player/blob/5eb7d0722e4a7706acda9c02c2dbd8ae632ce39d/src/videojs-analytics.js#L31

Not too opinionated on the api here, but we need something.