### PR TITLE
Ingest event loop

### DIFF
--- a/src/analytics-ingest/analytics-ingest.js
+++ b/src/analytics-ingest/analytics-ingest.js
@@ -24,12 +24,12 @@ var AnalyticsIngest = function (options) {
   this.endpoint = settings.ingestUrl;
 
   if (!settings.debugMode) {
-    setInterval(this.processEventQueue, 100);
+    setInterval(this.processFirstEvent, 100);
   }
 };
 
-AnalyticsIngest.prototype.processEventQueue = function () {
-  var processedUrl = eventQueue.pop();
+AnalyticsIngest.prototype.processFirstEvent = function () {
+  var processedUrl = eventQueue.shift();
 
   if (processedUrl) {
     var img = new Image();

--- a/src/analytics-ingest/analytics-ingest.js
+++ b/src/analytics-ingest/analytics-ingest.js
@@ -8,30 +8,63 @@ var _AnalyticsIngestError = function (message) {
 };
 _AnalyticsIngestError.prototype = Object.create(Error.prototype);
 
-var AnalyticsIngest = {
-  /**
-   * Sends the page information to the ingestion endpoint
-   */
-  sendEvent: function (endpoint) {
+var eventQueue;
 
-    if (typeof(endpoint) !== 'string') {
-      throw new _AnalyticsIngestError('Ingest endpoint must be set!');
-    }
+var AnalyticsIngest = function (options) {
+  var settings = $.extend({
+    debugMode: false
+  }, options);
 
-    var cacheBuster = (new Date()).getTime();
+  eventQueue = [];
 
-    var url =
-      endpoint +
-      '?' + cacheBuster +
-      '&hostname=' + window.location.hostname +
-      '&pathname=' + window.location.pathname +
-      '&search=' + window.location.search;
+  if (typeof(settings.ingestUrl) !== 'string') {
+    throw new _AnalyticsIngestError('Ingest endpoint must be set!');
+  }
 
-    setTimeout(function () {
-      var img = new Image();
-      img.src = url;
-    });
+  this.endpoint = settings.ingestUrl;
+
+  if (!settings.debugMode) {
+    setInterval(this.processEventQueue, 100);
   }
 };
 
-module.exports = AnalyticsIngest;
+AnalyticsIngest.prototype.processEventQueue = function () {
+  var processedUrl = eventQueue.pop();
+
+  if (processedUrl) {
+    var img = new Image();
+    img.src = processedUrl;
+  }
+
+  return processedUrl;
+};
+
+AnalyticsIngest.prototype.queueSize = function () {
+  return eventQueue.length;
+};
+
+AnalyticsIngest.prototype.enqueueUrl = function (url) {
+  eventQueue.push(url);
+};
+
+/**
+* Sends the page information to the ingestion endpoint
+*/
+AnalyticsIngest.prototype.sendEvent = function () {
+  var cacheBuster = (new Date()).getTime();
+
+  var url =
+    this.endpoint +
+    '?' + cacheBuster +
+    '&hostname=' + window.location.hostname +
+    '&pathname=' + window.location.pathname +
+    '&search=' + window.location.search;
+
+  this.enqueueUrl(url);
+};
+
+module.exports = {
+  init: function (options) {
+    return new AnalyticsIngest(options);
+  }
+};

--- a/src/analytics-ingest/analytics-ingest.spec.js
+++ b/src/analytics-ingest/analytics-ingest.spec.js
@@ -4,20 +4,56 @@ describe('AnalyticsIngest', function () {
 
   beforeEach(function () {
     sandbox = sinon.sandbox.create();
-    ingest = require('./analytics-ingest');
   });
 
   afterEach(function () {
     sandbox.restore();
   });
 
-  describe('sendEvent', function () {
+  context('with endpoint', function() {
+    beforeEach(function() {
+      var Ingest = require('./analytics-ingest');
+      ingest = Ingest.init({ debugMode: true, ingestUrl: 'http://ingest.onion.com/ingest.gif' });
+    });
+
+    describe('#processEventQueue', function() {
+      it('processes the first item in the queue if present', function () {
+        ingest.enqueueUrl('http://ingest.onion.com/ingest.gif');
+        var processedItem = ingest.processEventQueue();
+        expect(processedItem).to.equal('http://ingest.onion.com/ingest.gif');
+      });
+
+      it('does nothing if no items in queue', function() {
+        var processedItem = ingest.processEventQueue();
+        expect(processedItem).to.be.undefined;
+      });
+    });
+
+    describe('#enqueueUrl', function () {
+      it('enqueues a url', function() {
+        ingest.enqueueUrl('http://ingest.onion.com/ingest.gif');
+        expect(ingest.queueSize()).to.eql(1);
+      });
+    });
+
+    describe('#sendEvent', function () {
+      it('should enqueue an event', function() {
+        sandbox.stub(ingest, 'enqueueUrl');
+        ingest.sendEvent('http://ingest.onion.com/ingest.gif');
+        expect(ingest.enqueueUrl.called).to.be.true;
+      });
+    });
+  });
+
+  context('without endpoint', function() {
+    var Ingest;
+
+    beforeEach(function() {
+      Ingest = require('./analytics-ingest');
+    });
 
     it('should throw an error when no endpoint is provided', function () {
-      var func = sandbox.spy(ingest, 'sendEvent');
-      var notDefined;
-
-      expect(function () { func(notDefined); }).to.throw('AnalyticsIngestError');
-    });
+        expect(Ingest.init).to.throw('AnalyticsIngestError');
+      });
   });
 });

--- a/src/analytics-ingest/analytics-ingest.spec.js
+++ b/src/analytics-ingest/analytics-ingest.spec.js
@@ -16,15 +16,15 @@ describe('AnalyticsIngest', function () {
       ingest = Ingest.init({ debugMode: true, ingestUrl: 'http://ingest.onion.com/ingest.gif' });
     });
 
-    describe('#processEventQueue', function() {
+    describe('#processFirstEvent', function() {
       it('processes the first item in the queue if present', function () {
         ingest.enqueueUrl('http://ingest.onion.com/ingest.gif');
-        var processedItem = ingest.processEventQueue();
+        var processedItem = ingest.processFirstEvent();
         expect(processedItem).to.equal('http://ingest.onion.com/ingest.gif');
       });
 
       it('does nothing if no items in queue', function() {
-        var processedItem = ingest.processEventQueue();
+        var processedItem = ingest.processFirstEvent();
         expect(processedItem).to.be.undefined;
       });
     });

--- a/src/analytics-manager.js
+++ b/src/analytics-manager.js
@@ -23,6 +23,8 @@ var AnalyticsManager = {
       throw new _AnalyticsManagerError('Site name must be specified!');
     }
 
+    this.ingest = Ingest.init({ ingestUrl: this._settings.ingestUrl });
+
     this.trackedPaths = [];
     var body = document.getElementsByTagName('body');
     body[0].addEventListener('click', this.trackClick);
@@ -133,7 +135,7 @@ var AnalyticsManager = {
       this.sendQuantcastPixel(freshPage);
       this.sendComscorePixel(freshPage, optionalTitle);
 
-      Ingest.sendEvent(this._settings.ingestUrl);
+      this.ingest.sendEvent();
 
       this.trackedPaths.push(path);
     }


### PR DESCRIPTION
@daytonn @MelizzaP @collin @kand - This is ready to review.  Implementation is in this PR: https://github.com/theonion/omni/pull/162

Basically, this is deferring processing of pageview tracking to a simple event loop, instead of `setTimeout` so we don't have to listen to the document `load` event on our properties.  When using `setTimeout`, it was still render blocking.  The document `load` solution, however, was preventing GA tracking from firing as fast as it should and the thought is that's impacting numbers