### PR TITLE
add optionalGaPrefix to trackPageView

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "karma-browserify": "^4.2.1",
     "karma-chai": "^0.1.0",
     "karma-mocha": "^0.2.0",
-    "karma-phantomjs-launcher": "^0.2.0",
+    "karma-phantomjs-launcher": "^1.0.2",
     "karma-sinon": "^1.0.4",
     "mocha": "^2.2.5",
     "phantomjs": "^1.9.17",

--- a/src/analytics-manager.js
+++ b/src/analytics-manager.js
@@ -126,11 +126,11 @@ var AnalyticsManager = {
     return pathInfo;
   },
 
-  trackPageView: function(freshPage, optionalTitle, optionalGaPrefix) {
+  trackPageView: function(freshPage, optionalTitle, optionalGaTrackerAction) {
     var path = this.pathInfo();
     if (this.trackedPaths.indexOf(path) < 0) {
-      if (optionalGaPrefix) {
-        ga(optionalGaPrefix + '.send', 'pageview', path);
+      if (optionalGaTrackerAction) {
+        optionalGaTrackerAction('send', 'pageview', path);
       } else {
         ga('send', 'pageview', path);
       }

--- a/src/analytics-manager.js
+++ b/src/analytics-manager.js
@@ -128,15 +128,13 @@ var AnalyticsManager = {
 
   trackPageView: function(freshPage, optionalTitle, optionalGaPrefix) {
     var path = this.pathInfo();
-    if (optionalGaPrefix) {
-      var gaPrefix = optionalGaPrefix;
-    }
-    else {
-      var gaPrefix = 'adTracker';
-    }
     if (this.trackedPaths.indexOf(path) < 0) {
-      ga('send', 'pageview', path);
-      ga(gaPrefix + '.send', 'pageview', this._settings.site + path);
+      if (optionalGaPrefix) {
+        ga(optionalGaPrefix + '.send', 'pageview', path);
+      } else {
+        ga('send', 'pageview', path);
+      }
+      ga('adTracker.send', 'pageview', this._settings.site + path);
 
       this.sendQuantcastPixel(freshPage);
       this.sendComscorePixel(freshPage, optionalTitle);

--- a/src/analytics-manager.js
+++ b/src/analytics-manager.js
@@ -126,11 +126,17 @@ var AnalyticsManager = {
     return pathInfo;
   },
 
-  trackPageView: function(freshPage, optionalTitle) {
+  trackPageView: function(freshPage, optionalTitle, optionalGaPrefix) {
     var path = this.pathInfo();
+    if (optionalGaPrefix) {
+      var gaPrefix = optionalGaPrefix;
+    }
+    else {
+      var gaPrefix = 'adTracker';
+    }
     if (this.trackedPaths.indexOf(path) < 0) {
       ga('send', 'pageview', path);
-      ga('adTracker.send', 'pageview', this._settings.site + path);
+      ga(gaPrefix + '.send', 'pageview', this._settings.site + path);
 
       this.sendQuantcastPixel(freshPage);
       this.sendComscorePixel(freshPage, optionalTitle);

--- a/src/analytics-manager.js
+++ b/src/analytics-manager.js
@@ -126,11 +126,11 @@ var AnalyticsManager = {
     return pathInfo;
   },
 
-  trackPageView: function(freshPage, optionalTitle, optionalGaTrackerAction) {
+  trackPageView: function(freshPage, optionalTitle, optionalGaWrappedTracker) {
     var path = this.pathInfo();
     if (this.trackedPaths.indexOf(path) < 0) {
-      if (optionalGaTrackerAction) {
-        optionalGaTrackerAction('send', 'pageview', path);
+      if (optionalGaWrappedTracker) {
+        optionalGaWrappedTracker('send', 'pageview', path);
       } else {
         ga('send', 'pageview', path);
       }

--- a/src/analytics-manager.spec.js
+++ b/src/analytics-manager.spec.js
@@ -425,19 +425,33 @@ describe("AnalyticsManager", function() {
 
   describe('#trackPageView', function () {
     var pathInfo;
+    var counter = 0;
 
     beforeEach( function () {
-      pathInfo = sinon.stub(subject, 'pathInfo').returns('website');
+      pathInfo = sinon.stub(subject, 'pathInfo').returns('website' + parseInt(counter++));
     });
     afterEach( function () {
       pathInfo.restore();
     });
 
-    it('sends pageview with optionalGaPrefix', function () {
-      subject.trackPageView('/fresh/page/path', 'funTitle', 'websitePage345');
+    it('sends pageview', function () {
+      subject.trackPageView('/fresh/page/path', 'funTitle');
       var expected = window.ga
-        .calledWith('websitePage345.send', 'pageview', 'website');
+        .calledWith('send', 'pageview', 'website' + parseInt(counter - 1));
       expect(expected).to.be.true;
     });
+
+    it('sends pageview with optionalGaTrackerAction', function () {
+      var optionalGaTrackerAction = sandbox.stub();
+      subject.trackPageView(
+        '/fresh/page/path',
+        'funTitle',
+        optionalGaTrackerAction
+      );
+      var expected = optionalGaTrackerAction
+        .calledWith('send', 'pageview', 'website' + parseInt(counter - 1));
+      expect(expected).to.be.true;
+    });
+
   });
 });

--- a/src/analytics-manager.spec.js
+++ b/src/analytics-manager.spec.js
@@ -422,4 +422,22 @@ describe("AnalyticsManager", function() {
     });
 
   });
+
+  describe('#trackPageView', function () {
+    var pathInfo;
+
+    beforeEach( function () {
+      pathInfo = sinon.stub(subject, 'pathInfo').returns('website');
+    });
+    afterEach( function () {
+      pathInfo.restore();
+    });
+
+    it('sends pageview with optionalGaPrefix', function () {
+      subject.trackPageView('/fresh/page/path', 'funTitle', 'websitePage345');
+      var expected = window.ga
+        .calledWith('websitePage345.send', 'pageview', 'website');
+      expect(expected).to.be.true;
+    });
+  });
 });

--- a/src/analytics-manager.spec.js
+++ b/src/analytics-manager.spec.js
@@ -442,16 +442,15 @@ describe("AnalyticsManager", function() {
     });
 
     it('sends pageview with optionalGaTrackerAction', function () {
-      var optionalGaTrackerAction = sandbox.stub();
+      var optionalGaWrappedTracker = sandbox.stub();
       subject.trackPageView(
         '/fresh/page/path',
         'funTitle',
-        optionalGaTrackerAction
+        optionalGaWrappedTracker
       );
-      var expected = optionalGaTrackerAction
+      var expected = optionalGaWrappedTracker
         .calledWith('send', 'pageview', 'website' + parseInt(counter - 1));
       expect(expected).to.be.true;
     });
-
   });
 });


### PR DESCRIPTION
update to the analytics manager, that allows a function wrapper to be passed in from `bulbs-elements` util prep ga-event-tracker https://github.com/theonion/bulbs-elements/blob/master/lib/bulbs-elements/util/prep-ga-event-tracker.js 