### PR TITLE
Remove adTracker pageview event

### DIFF
--- a/src/analytics-manager.js
+++ b/src/analytics-manager.js
@@ -133,7 +133,6 @@ var AnalyticsManager = {
       } else {
         ga('send', 'pageview', path);
       }
-      ga('adTracker.send', 'pageview', this._settings.site + path);
 
       this.sendQuantcastPixel(freshPage);
       this.sendComscorePixel(freshPage, optionalTitle);


### PR DESCRIPTION
## What?

No longer using rollup account on Clickhole, this cleans up last remaining `adTracker` reference. 

Will be used by Clickhole PR https://github.com/theonion/omni/pull/1406.